### PR TITLE
Replace NonNotifiableAttr with IgnoreAttr

### DIFF
--- a/Teeny.Core/Scan/Attributes/IgnoreAttribute.cs
+++ b/Teeny.Core/Scan/Attributes/IgnoreAttribute.cs
@@ -2,7 +2,7 @@
 
 namespace Teeny.Core.Scan.Attributes
 {
-    public class NonNotifiableAttribute : Attribute
+    public class IgnoreAttribute : Attribute
     {
     }
 }

--- a/Teeny.Core/Scan/Scanner.cs
+++ b/Teeny.Core/Scan/Scanner.cs
@@ -47,23 +47,23 @@ namespace Teeny.Core.Scan
             if (token == Token.Unknown)
             {
                 var errorType = CategorizeError(lexemeStr);
-                var errorRecord = new ErrorRecord
+                ErrorTable.Add(new ErrorRecord
                 {
                     Lexeme = lexemeStr,
                     ErrorType = errorType
-                };
+                });
 
-                ErrorTable.Add(errorRecord);
                 return;
             }
 
-            var tokenRecord = new TokenRecord
+            var ignorable = token.GetAttributeOfType<IgnoreAttribute>() != null;
+            if (ignorable) return;
+
+            TokensTable.Add(new TokenRecord
             {
                 Lexeme = lexemeStr,
                 Token = token
-            };
-
-            TokensTable.Add(tokenRecord);
+            });
         }
 
         private Token Tokenize(string lexeme)

--- a/Teeny.Core/Scan/ScannerState.cs
+++ b/Teeny.Core/Scan/ScannerState.cs
@@ -7,9 +7,9 @@ namespace Teeny.Core.Scan
 {
     public class ScannerState
     {
-        private ScannerStateType _stateType = ScannerStateType.Unknown;
         private StringBuilder Lexeme { get; } = new StringBuilder();
 
+        private ScannerStateType _stateType = ScannerStateType.Unknown;
         public ScannerStateType StateType
         {
             get => _stateType;
@@ -17,12 +17,8 @@ namespace Teeny.Core.Scan
             {
                 if (_stateType == value) return;
 
-                // Notifiable states: ScanEnd and any state without NonNotifiableAttribute
-                var hasNonNotifiableAttribute = _stateType.GetAttributeOfType<NonNotifiableAttribute>() != null;
-                var isNotifiable = value == ScannerStateType.ScanEnd || !hasNonNotifiableAttribute;
-                
-                // Notify for change if the state is notifiable and there's a lexeme to notify for
-                if (isNotifiable && Lexeme.Length > 0) OnStateChanged(Lexeme);
+                // Notify for change if there's a lexeme to notify for
+                if (Lexeme.Length > 0) OnStateChanged(Lexeme);
 
                 // Update type and start a new lexeme
                 _stateType = value;

--- a/Teeny.Core/Scan/ScannerStateType.cs
+++ b/Teeny.Core/Scan/ScannerStateType.cs
@@ -4,7 +4,7 @@ namespace Teeny.Core.Scan
 {
     public enum ScannerStateType
     {
-        [NonNotifiable] ScanStart,
+        ScanStart,
         ScanEnd,
 
         ScanAlphanumeric,
@@ -13,10 +13,9 @@ namespace Teeny.Core.Scan
         ScanOpenedBracket,
         ScanClosedBracket,
 
-        [NonNotifiable] ScanWhitespace,
+        ScanWhitespace,
 
-        [Stream] [NonNotifiable] ScanComment,
-
+        [Stream] ScanComment,
         [Stream] ScanString,
 
         CloseStream,

--- a/Teeny.Core/Scan/Token.cs
+++ b/Teeny.Core/Scan/Token.cs
@@ -54,6 +54,9 @@ namespace Teeny.Core.Scan
 
         [ConstantToken("(")] ParenthesisLeft,
         [ConstantToken(")")] ParenthesisRight,
+
+        [Ignore] [PatternToken(@"^/\*(.|\s)*\*/$")] Comment,
+        [Ignore] [PatternToken(@"^\s+")] Whitespace,
         Unknown
     }
 }


### PR DESCRIPTION
Stop using the NonNotifiable Attribute from the ScannerState and use a similar approach from the Scanner itself using an attribute for Token Enum called "Ignore", to make sure that the NonNotifiable states still get some error checking before they get ignored (e.g. a comment with an unclosed tag).