### PR TITLE
Decrease Parser Unit Tests' Time

### DIFF
--- a/Teeny.Core.Tests/ParserTest.cs
+++ b/Teeny.Core.Tests/ParserTest.cs
@@ -169,7 +169,11 @@ namespace Teeny.Core.Tests
             _parser.Parse(tokensTable);
 
             // Assert
-            _parser.ProgramRoot.ShouldDeepEqual(expectedProgram);
+            Assert.AreEqual(0, _parser.ErrorList.Count);
+            _parser.ProgramRoot.WithDeepEqual(expectedProgram)
+                .IgnoreProperty<Node>(n => n.Children)
+                .IgnoreProperty<Node>(n => n.Name)
+                .Assert();
         }
 
         [TestMethod]
@@ -268,8 +272,11 @@ namespace Teeny.Core.Tests
             _parser.Parse(tokensTable);
 
             // Assert
-            _parser.ProgramRoot.ShouldDeepEqual(expectedProgram);
             Assert.AreEqual(0, _parser.ErrorList.Count);
+            _parser.ProgramRoot.WithDeepEqual(expectedProgram)
+                .IgnoreProperty<Node>(n => n.Children)
+                .IgnoreProperty<Node>(n => n.Name)
+                .Assert();
         }
     }
 }


### PR DESCRIPTION
Removing unnecessary properties from the deep equality between actual and expected values, decreased the tests time from 1 sec to 120 ms.